### PR TITLE
DTSPO-15860: Add fees-register access

### DIFF
--- a/entitlement-packages.yml
+++ b/entitlement-packages.yml
@@ -424,4 +424,4 @@ packages:
       - "DTS Readers (sub:dts-management-prod-intsvc)"
       - "DTS Readers (sub:dts-management-nonprod-intsvc)"
       - "DTS Readers (sub:dts-management-sbox-intsvc)"
-
+      


### PR DESCRIPTION
Updated to allow access for ccpay readers to the fees-resgister db.

### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15860


### Change description ###
Fees Register DB access in Production

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
