### PR TITLE
DTSPO-14819 Add missing access packages

### DIFF
--- a/entitlement-packages.yml
+++ b/entitlement-packages.yml
@@ -217,6 +217,19 @@ packages:
       - "DTS JIT Access bar DB Reader SC"
       - "DTS JIT Access fees-register DB Reader SC"
 
+  - name: "Database - civil read access"
+    description: "Grants read access to civil databases"
+    catalog_name: "Databases"
+    policies:
+      - name: "Database"
+        requestor_groups:
+          - "DTS CFT SC"
+        approver_groups:
+          - "DTS Platform Operations"
+    resource_roles:
+      - "DTS Production Bastion Access for Users (DevOps)"
+      - "DTS JIT Access civil DB Reader SC"
+
   - name: "Database - AM read access"
     description: "Grants read access to AM databases"
     catalog_name: "Databases"
@@ -267,6 +280,17 @@ packages:
           - "DTS Platform Operations SC"
     resource_roles:
       - "DTS Production Bastion Access for Users (SecOps)"
+
+  - name: "SecOps Sandbox Bastion Server Access"
+    description: "This will provide access to Bastion Servers for SecOps in Sandbox (SBOX) environments."
+    catalog_name: "Bastion Servers"
+    policies:
+      - name: "self-approval"
+        requestor_groups:
+          - "dcd_team_secops_v2"
+          - "DTS Platform Operations SC"
+    resource_roles:
+      - "DTS Non-Production Bastion Access for Users (SecOps)"
 
   - name: "Non-Production Bastion Server Access"
     description: "This will provide access to Bastion Servers in Non-Production environments."

--- a/package-policies/database.yml
+++ b/package-policies/database.yml
@@ -17,8 +17,8 @@ policy:
     enabled: false
   extension_enabled: true
   questions:
-  - required: true
-    sequence: 1
+  - required: false
+    sequence: 0
     text:
       default_text: "Include Jira link in business justification"
   requestor_settings:


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-14819


### Change description ###

I ran:
```
$ yq '.packages | length' entitlement-packages.yml
31
```

Whereas the portal had 33.

I found 2 missing. (I haven't compared every single one but I think that should be fine)

The state has all been imported locally


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
