### PR TITLE
DTSPO-17204 - increase duration for SC package

### DIFF
--- a/package-policies/security-clearance-form.yml
+++ b/package-policies/security-clearance-form.yml
@@ -3,7 +3,7 @@ name: "security-clearance-form"
 policy:
   display_name: "Initial Policy"
   description: "Initial Policy"
-  duration_in_days: 180
+  duration_in_days: 365
   extension_enabled: false
   questions:
   - required: true


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17204

### Change description ###
I had a call with Michael Barrie (he does the SC approvals) to check on his side if there would be any issues in extending this and he is fine with it
SC is usually granted for several years so this will mean people won't have to re-request the access package as often
Required due to the new checks we have on devops-azure-ad

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
