### PR TITLE
Change label text for self approval

### DIFF
--- a/package-policies/database-self-approval-with-justification.yml
+++ b/package-policies/database-self-approval-with-justification.yml
@@ -14,7 +14,7 @@ policy:
   - required: true
     sequence: 0
     text:
-      default_text: "Include Jira link in business justification"
+      default_text: "Jira link"
   requestor_settings:
     requestor:
       subject_type: "groupMembers"


### PR DESCRIPTION
It was "Include link in business justification" before as business justification shows in approval emails whereas custom fields didn't (at least when it was implemented)

Since this field is now mandatory it should be asking you to put the Jira link inside the field

Relates to https://tools.hmcts.net/jira/browse/DTSPO-17576