### PR TITLE
[DTSPO-18406] Allow Cpp DevOps to request SC Access package

### DIFF
--- a/entitlement-packages.yml
+++ b/entitlement-packages.yml
@@ -494,6 +494,7 @@ packages:
         requestor_groups:
           - "DTS CFT Developers"
           - "DTS SDS Developers"
+          - "Cpp DevOps"
         approver_groups:
           - "DTS SC Access Approvers"
     resource_roles:


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-18406


### Change description ###
Allows Crime users to also request this package so that their SC can be validated prior to being given access

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
