### PR TITLE
DTSPO-24310: Adding access packages for admin access to databases

### DIFF
--- a/entitlement-packages.yml
+++ b/entitlement-packages.yml
@@ -639,7 +639,7 @@ packages:
       - "DTS JIT Access et DB Reader SC"
       - "DTS Production Bastion Access for Users (DevOps)"
 
-  - name: "Administrative Access - PostgreSQL"
+  - name: "PlatOps PostgreSQL Administrative Access"
     description: "Grants admin access to PostgreSQL databases"
     catalog_name: "Databases"
     policies:
@@ -649,7 +649,7 @@ packages:
     resource_roles:
       - "PlatOps PostgreSQL Admin Access"
 
-  - name: "Administrative Access - PostgreSQL SC"
+  - name: "PlatOps PostgreSQL Administrative Access SC"
     description: "Grants admin access to PostgreSQL databases SC"
     catalog_name: "Databases"
     policies:


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25133

### Change description

- Adding access packages for admin access to postgreSQL databases
- Access packages self approve with justification
- Can only be requested by members of "DTS Platform Operations" and "DTS Platform Operations SC"
- This is needed so we can replace all members of "DTS Platform Operations" and "DTS Platform Operations SC" having admin access to databases with access packages that can be requested

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
