### PR TITLE
DTSPO-25133: Adding PostgreSQL groups to database catalogue

### DIFF
--- a/entitlement-catalogs.yml
+++ b/entitlement-catalogs.yml
@@ -137,6 +137,8 @@ catalogs:
       - "DTS JIT Access xui DB Reader SC"
       - "DTS Production Bastion Access for Users (DevOps)"
       - "DTS JIT Access ccd DB Writer SC"
+      - "PlatOps PostgreSQL Admin Access"
+      - "PlatOps PostgreSQL Admin Access SC"
 
   - name: "SharedServices Subscriptions CT"
     description: "DTS-SharedServices Subscriptions"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25133

### Change description

- Adding "PlatOps PostgreSQL Admin Access" and "PlatOps PostgreSQL Admin Access SC" to the Databases catalogue.
- A continuation of [this PR](https://github.com/hmcts/azure-access-packages/pull/89/files). Adding the groups so they can be assigned as resources in those access packages.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
