### PR TITLE
Implement JIT access for Pre-Recorded Evidence databases

### DIFF
--- a/entitlement-catalogs.yml
+++ b/entitlement-catalogs.yml
@@ -128,7 +128,6 @@ catalogs:
       - "DTS JIT Access pcq DB Reader SC"
       - "DTS JIT Access pip DB Reader SC"
       - "DTS JIT Access pre DB Reader SC"
-      - "DTS JIT Access pre DB Writer SC"
       - "DTS JIT Access probate DB Reader SC"
       - "DTS JIT Access rd DB Reader SC"
       - "DTS JIT Access reform-scan DB Reader SC"

--- a/entitlement-packages.yml
+++ b/entitlement-packages.yml
@@ -434,19 +434,6 @@ packages:
       - "DTS JIT Access pre DB Reader SC"
       - "DTS Production Bastion Access for Users (DevOps)"
 
-  - name: "Database - PRE write access - self approval"
-    description: "Grants write access to Pre-Recorded Evidence databases"
-    catalog_name: "Databases"
-    policies:
-      - name: "Database-self-approval-with-justification"
-        requestor_groups:
-          - "DTS Pre-Recorded Evidence BAU Developers"
-        approver_groups:
-          - "DTS Pre-Recorded Evidence BAU Admin"
-    resource_roles:
-      - "DTS JIT Access pre DB Writer SC"
-      - "DTS Production Bastion Access for Users (DevOps)"
-
   - name: "Database - CMC read access - self approval"
     description: "Grants read access to CMC databases"
     catalog_name: "Databases"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/S28-3809

Dependent on https://github.com/hmcts/azure-access/pull/5444 

### Change description

Add read-only JIT access for Pre-Recorded Evidence databases

This is so that the BAU team is able to investigate the database for a known recurring P1 issue on the Pre-Recorded Evidence project (e.g. INC5708438). 


