### PR TITLE
DTSPO-25133: use standardise name for PostgreSQL admin groups

### DIFF
--- a/entitlement-catalogs.yml
+++ b/entitlement-catalogs.yml
@@ -138,8 +138,8 @@ catalogs:
       - "DTS JIT Access xui DB Reader SC"
       - "DTS Production Bastion Access for Users (DevOps)"
       - "DTS JIT Access ccd DB Writer SC"
-      - "PlatOps PostgreSQL Admin Access"
-      - "PlatOps PostgreSQL Admin Access SC"
+      - "DTS Platform Operations PostgreSQL Admin Access"
+      - "DTS Platform Operations PostgreSQL Admin Access SC"
 
   - name: "SharedServices Subscriptions CT"
     description: "DTS-SharedServices Subscriptions"

--- a/entitlement-packages.yml
+++ b/entitlement-packages.yml
@@ -660,7 +660,7 @@ packages:
         requestor_groups:
           - "DTS Platform Operations"
     resource_roles:
-      - "PlatOps PostgreSQL Admin Access"
+      - "DTS Platform Operations PostgreSQL Admin Access"
 
   - name: "PlatOps PostgreSQL Administrative Access SC"
     description: "Grants admin access to PostgreSQL databases SC"
@@ -670,7 +670,7 @@ packages:
         requestor_groups:
           - "DTS Platform Operations SC"
     resource_roles:
-      - "PlatOps PostgreSQL Admin Access SC"
+      - "DTS Platform Operations PostgreSQL Admin Access SC"
 
   - name: "Security Administrators Access"
     description: "Grants the Security Administrator assigned role" 


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25133


### Change description

- Update catalog and package to use renamed and standardised group name for Postgresql admin access


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
