### PR TITLE
Add PCS database access package

### DIFF
--- a/entitlement-catalogs.yml
+++ b/entitlement-catalogs.yml
@@ -125,6 +125,7 @@ catalogs:
       - "DTS JIT Access owaspdependency DB Reader SC"
       - "DTS JIT Access pact-broker DB Reader SC"
       - "DTS JIT Access payment DB Reader SC"
+      - "DTS JIT Access pcs DB Reader SC"
       - "DTS JIT Access pcq DB Reader SC"
       - "DTS JIT Access pip DB Reader SC"
       - "DTS JIT Access pre DB Reader SC"

--- a/entitlement-packages.yml
+++ b/entitlement-packages.yml
@@ -28,6 +28,19 @@ packages:
       - "DTS JIT Access pcq DB Reader SC"
       - "DTS Production Bastion Access for Users (DevOps)"
 
+  - name: "Database - PCS read access - self approval"
+    description: "Grants read access to PCS database"
+    catalog_name: "Databases"
+    policies:
+      - name: "Database-self-approval-with-justification"
+        requestor_groups:
+          - "DTS CFT SC"
+        approver_groups:
+          - "DTS Platform Operations"
+    resource_roles:
+      - "DTS JIT Access pcs DB Reader SC"
+      - "DTS Production Bastion Access for Users (DevOps)"
+
   - name: "Database - Probate read access - self approval"
     description: "Grants read access to probate database"
     catalog_name: "Databases"


### PR DESCRIPTION
### Change description

Add a self-service PCS database read access package for members of `DTS CFT SC`. The package grants temporary membership of `DTS JIT Access pcs DB Reader SC` together with production Bastion access, using the standard database justification policy.

Depends on [hmcts/azure-access#7726](https://github.com/hmcts/azure-access/pull/7726) creating the reader group first.

The corresponding PCS schema permissions are in [hmcts/pcs-api#2236](https://github.com/hmcts/pcs-api/pull/2236).
